### PR TITLE
docs: update link to ProtonVPN iOS app

### DIFF
--- a/providers/index.html
+++ b/providers/index.html
@@ -93,7 +93,7 @@
   <li><a href="https://hide.me">Hide.me</a></li>
   <li><a href="https://github.com/ivpn/ios-app/blob/develop/ACKNOWLEDGEMENTS.md#tunnelkit">IVPN</a></li>
   <li><a href="https://github.com/pia-foss/vpn-ios#acknowledgements">PIA</a></li>
-  <li><a href="https://github.com/ProtonVPN/ios-app/blob/master/ACKNOWLEDGEMENTS.md#tunnelkit">ProtonVPN</a></li>
+  <li><a href="https://github.com/ProtonVPN/ios-mac-app/blob/develop/ACKNOWLEDGEMENTS.md#tunnelkit">ProtonVPN</a></li>
 </ul>
 
 <h3 id="contacts">Contacts</h3>


### PR DESCRIPTION
ios-app is archived, ios-mac-app is used instead